### PR TITLE
Feat/test auto assign 1

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,6 +10,6 @@ jobs:
   add-reviews:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.2.6
+      - uses: kentaro-m/auto-assign-action@v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,5 +3,3 @@
 After extensively using Notion for tech notes, I've recently transitioned to a GitHub repo. This shift allows me to enjoy the process more, enrich my GitHub profile, and showcase my efforts, as GitHub tracks and visually represents all activities.
 
 [Check it out!](https://github.com/japananh/TIL/issues)
-
-Test workflow!!!


### PR DESCRIPTION
## Summary by Sourcery

Update the GitHub Actions workflow to use the latest version of the auto-assign-action and clean up the README.md file by removing a test line.

CI:
- Update the GitHub Actions workflow to use version 2.0.0 of the auto-assign-action.

Documentation:
- Remove a test line from the README.md file.